### PR TITLE
Add a default template for all repositories

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+- [ ] Code is tested and tests pass
+- [ ] Any network changes have been vetted
+
+Contributes to https://github.com/trustsitka/sitka/issues/
+
+@trustsitka/dev


### PR DESCRIPTION
This can be overridden with a repository-specific template if needed. Having a default ticks a lot of boxes in Vanta.

@trustsitka/dev 