### PR TITLE
need to have the shared template at the root

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,3 @@
-- [ ] Code is tested and tests pass
-- [ ] Any network changes have been vetted
-
 Contributes to https://github.com/trustsitka/sitka/issues/
 
 @trustsitka/dev

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,6 @@
+- [ ] Code is tested and tests pass
+- [ ] Any network changes have been vetted
+
+Contributes to https://github.com/trustsitka/sitka/issues/
+
+@trustsitka/dev


### PR DESCRIPTION
I made a mistake. The shared templates need to go in the root and so I updated the one for this repository.

Contributes to Fixing a ton of vanta alerts. https://app.vanta.com/activity#code-review-network-evaluation

@trustsitka/dev
